### PR TITLE
update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@ ZipManager class will zip or unzip large zip archives super fast using native pr
 
 in AS3, there are many different zip libraries which will do the same thing but they are not good enough when it comes to mobile usage because of the following reasons:
 
-– They load the whole zip into runtime and then try to zip/unzip reading bytes which is too time consuming
-– loading a big zip file using AS3 libraries will fail on mobile devices because it takes too much RAM
-– AS workers are not yet supported on iOS and your Air UI will freez untill the process is finished!
-– the bottom line is that AS3 libs for handling zip files are TOO slow and not practical
+â€“ They load the whole zip into runtime and then try to zip/unzip reading bytes which is too time consuming
+â€“ loading a big zip file using AS3 libraries will fail on mobile devices because it takes too much RAM
+â€“ AS workers are not yet supported on iOS and your Air UI will freez untill the process is finished!
+â€“ the bottom line is that AS3 libs for handling zip files are TOO slow and not practical
 
 using this extension will solve all the above problems. you will be amazed how fast it works no matter the size of the zip file. we tested with a ~1GB zip archive and it worked just fine :) 
 
@@ -61,6 +61,9 @@ function onComplete(e:ZipManagerEvent):void
     <extensionID>com.myflashlab.air.extensions.zipManager</extensionID>
   </extensions>
 ```
+
+# Loading from File.applicationDirectory - where it is returned empty on android, but actually contains files
+which names have to be know in advance.
 
 # Requirements
 * Android SDK 10 or higher


### PR DESCRIPTION
Questions / Issues
Seems to be problem loading a file from applicationDirectory on Android.
Since applicationDirectory is returned empty (for some reason)

The only way to load an asset bundled with the APK is to resolve
a path but load using URLLoader since nativePath is not available.

when running this ANE: i get the following error:
zip process ERROR: java.io.FileNotFoundException: /storage/emulated/0: open failed: EISDIR (Is a directory)

but I'm passing a File Reference that is resolved to a zip file inside applicationDirectory.
It can be loaded using a url loader, and the File reference returns true for both .exists / .size
but We cannot loaded it using nativePath.

Any ideas how to proceed?

I would recommend:
- Try load file using the .url property if nativePath is not available.
- allow unzipping from a ByteArray - since i can access it easily via the URLLoader.

thanks
